### PR TITLE
Update hamming_test.spec.js

### DIFF
--- a/hamming/hamming_test.spec.js
+++ b/hamming/hamming_test.spec.js
@@ -1,4 +1,4 @@
-var compute = require('./hamming').compute;
+var compute = require('./hamming');
 
 describe('Hamming', function () {
 


### PR DESCRIPTION
Removing `.compute` from the test makes the user use `module.exports = compute;`, instead of `exports.compute = compute;`, when they create their hamming.js module.

This change keeps this test consistent with the tests prior to hamming.

When I attempted hamming I was getting the error "Undefined is not a function," for the first test, even when I was simply returning 0 (the expected answer). It was difficult to search for an answer on the web and finally found the answer when I compared the hamming_test file with word_count_test file.