### PR TITLE
Added single string test to javascript anagram tests

### DIFF
--- a/anagram/anagram_test.spec.js
+++ b/anagram/anagram_test.spec.js
@@ -72,4 +72,10 @@ describe('Anagram', function() {
     expect(matches).toEqual(["tan"]);
   });
 
+  xit("matches() accepts single string argument",function() {
+    var subject = anagram("ant");
+    var matches = subject.matches("tan");
+
+    expect(matches).toEqual(["tan"]);
+  });
 });


### PR DESCRIPTION
I found a submission where the coder was testing for length of arguments to decide what to do... this case wouldn't have worked.