### PR TITLE
Rename xit to it in specs in temp directory before running them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ test-assignment: node_modules
 	@echo "running tests for: $(ASSIGNMENT)"
 	@cp $(ASSIGNMENT)/$(TSTFILE) $(OUTDIR)
 	@cp $(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
+	@sed -i.original 's/\bxit\b/it/g' $(OUTDIR)/*spec.$(FILEEXT)
 	@./node_modules/.bin/jasmine-node --captureExceptions $(OUTDIR)/$(TSTFILE)
 
 test:


### PR DESCRIPTION
Allows the example to be tested against all the specs, including the ones that were marked not to be run right away with xit.

Possible solution to Issue #71

I tested this on my Ubuntu machine. I'd want to see if it worked on Travis and in any other environments that need to be supported before being confident of it.