### PR TITLE
'octal' is missing a unit test for invalid digits

### DIFF
--- a/octal/example.js
+++ b/octal/example.js
@@ -3,13 +3,18 @@
 var BASE = 8;
 
 function Octal(octal) {
-  this.digits = octal.split('').reverse().map(Number);
+  this.digits = octal.split('').reverse().map(this.digitValue);
 }
 
 Octal.prototype.toDecimal = function() {
   var decimal = this.digits.reduce(this.accumulator, 0);
   return isNaN(decimal) ? 0 : decimal;
 };
+
+Octal.prototype.digitValue = function(value) {
+  var result = Number(value);
+  return (result < BASE)? result : Number.NaN;
+}
 
 Octal.prototype.accumulator = function(decimal, digit, index) {
   return decimal += digit * Math.pow(BASE, index);

--- a/octal/octal_test.spec.js
+++ b/octal/octal_test.spec.js
@@ -38,4 +38,8 @@ describe('octal', function() {
     expect(new Octal('carrot').toDecimal()).toEqual(0);
   });
 
+  xit('considers the digit 8 as invalid', function() {
+    expect(new Octal('12345678').toDecimal()).toEqual(0);
+  });
+
 });

--- a/queen-attack/example.js
+++ b/queen-attack/example.js
@@ -22,10 +22,14 @@ module.exports = function(options) {
       canAttack = true;
     }
 
-    var yDiagonal = this.white[0] - this.black[0];
-    var xDiagonal = this.white[1] - this.black[1];
+    var yDistance = this.white[0] - this.black[0];
+    var xDistance = this.white[1] - this.black[1];
 
-    if (xDiagonal === yDiagonal) {
+    if (xDistance === yDistance) {
+      canAttack = true;
+    }
+
+    if (xDistance === -yDistance) {
       canAttack = true;
     }
 

--- a/queen-attack/queen-attack_test.spec.js
+++ b/queen-attack/queen-attack_test.spec.js
@@ -69,4 +69,14 @@ _ _ _ _ _ _ _ _\n\
     expect(queens.canAttack()).toEqual(true);
   });
 
+  xit("queens can attack on a north-east/south-west diagonal", function() {
+    var queens = new Queens({ white: [7, 0], black: [0, 7] });
+    expect(queens.canAttack()).toEqual(true);
+  });
+
+  xit("queens can attack on another ne/sw diagonal", function() {
+    var queens = new Queens({ white: [2, 6], black: [5, 3] });
+    expect(queens.canAttack()).toEqual(true);
+  });
+
 });


### PR DESCRIPTION
There is a unit test, that tests if "carrot" is converted to 0, but there is no unit test for inputs containing invalid digits, e.g. '8'. The example implementation does not validate the input, too.