### PR TITLE
octal: added missing test case / fixed implementation

### DIFF
--- a/octal/example.js
+++ b/octal/example.js
@@ -3,13 +3,18 @@
 var BASE = 8;
 
 function Octal(octal) {
-  this.digits = octal.split('').reverse().map(Number);
+  this.digits = octal.split('').reverse().map(this.digitValue);
 }
 
 Octal.prototype.toDecimal = function() {
   var decimal = this.digits.reduce(this.accumulator, 0);
   return isNaN(decimal) ? 0 : decimal;
 };
+
+Octal.prototype.digitValue = function(value) {
+  var result = Number(value);
+  return (result < BASE)? result : Number.NaN;
+}
 
 Octal.prototype.accumulator = function(decimal, digit, index) {
   return decimal += digit * Math.pow(BASE, index);

--- a/octal/octal_test.spec.js
+++ b/octal/octal_test.spec.js
@@ -38,4 +38,8 @@ describe('octal', function() {
     expect(new Octal('carrot').toDecimal()).toEqual(0);
   });
 
+  xit('considers the digit 8 as invalid', function() {
+    expect(new Octal('12345678').toDecimal()).toEqual(0);
+  });
+
 });


### PR DESCRIPTION
There is a unit test, that tests if "carrot" is converted to 0, but there is no unit test for inputs containing invalid digits, e.g. '8'. The example implementation does not validate the input, too.