### PR TITLE
queen-attack: added missing test case / fixed implementation

### DIFF
--- a/queen-attack/example.js
+++ b/queen-attack/example.js
@@ -22,10 +22,14 @@ module.exports = function(options) {
       canAttack = true;
     }
 
-    var yDiagonal = this.white[0] - this.black[0];
-    var xDiagonal = this.white[1] - this.black[1];
+    var yDistance = this.white[0] - this.black[0];
+    var xDistance = this.white[1] - this.black[1];
 
-    if (xDiagonal === yDiagonal) {
+    if (xDistance === yDistance) {
+      canAttack = true;
+    }
+
+    if (xDistance === -yDistance) {
       canAttack = true;
     }
 

--- a/queen-attack/queen-attack_test.spec.js
+++ b/queen-attack/queen-attack_test.spec.js
@@ -69,4 +69,14 @@ _ _ _ _ _ _ _ _\n\
     expect(queens.canAttack()).toEqual(true);
   });
 
+  xit("queens can attack on a north-east/south-west diagonal", function() {
+    var queens = new Queens({ white: [7, 0], black: [0, 7] });
+    expect(queens.canAttack()).toEqual(true);
+  });
+
+  xit("queens can attack on another ne/sw diagonal", function() {
+    var queens = new Queens({ white: [2, 6], black: [5, 3] });
+    expect(queens.canAttack()).toEqual(true);
+  });
+
 });


### PR DESCRIPTION
The unit tests and the example implementation test the north-west / south-east diagonal, but are missing the north-east / south-west diagonal.
I just added two test cases and amended the example implementation.