### PR TITLE
Add test case for leading or trailing whitespace.

### DIFF
--- a/word-count/example.js
+++ b/word-count/example.js
@@ -2,7 +2,7 @@
 
 module.exports = function (input) {
   var counts = {};
-  var words = input.split(/\s+/);
+  var words = input.match(/\S+/g);
 
   words.forEach(function (word) {
     counts[word] = counts.hasOwnProperty(word) ? counts[word] + 1 : 1;

--- a/word-count/word-count_test.spec.js
+++ b/word-count/word-count_test.spec.js
@@ -51,6 +51,11 @@ describe("words()", function() {
     expect(words("hello  world")).toEqual(expectedCounts);
   });
 
+  xit("does not count leading or trailing whitespace", function() {
+    var expectedCounts = { Introductory: 1, Course: 1 };
+    expect(words("\t\tIntroductory Course      ")).toEqual(expectedCounts);
+  });
+
   xit("handles properties that exist on Object’s prototype", function() {
     var expectedCounts = { reserved: 1, words : 1, like :1,  prototype: 1, and : 1, toString: 1,  "ok?": 1};
     expect(words("reserved words like prototype and toString ok?")).toEqual(expectedCounts);


### PR DESCRIPTION
Strings with leading or trailing whitespace should not increment the total word count.