### PR TITLE
custom-set: BUG FIX #65. Define empty sets as disjointed.

### DIFF
--- a/custom-set/custom-set_test.spec.js
+++ b/custom-set/custom-set_test.spec.js
@@ -27,7 +27,7 @@ describe('CustomSet', function() {
     var actual2 = new CustomSet([1, 2]).disjoint(new CustomSet([2, 3]));
     expect(actual2).toBe(false);
     var actual3 = new CustomSet().disjoint(new CustomSet());
-    expect(actual3).toBe(false);
+    expect(actual3).toBe(true);
   });
 
   xit('can be emptied', function() {

--- a/custom-set/example.js
+++ b/custom-set/example.js
@@ -27,7 +27,7 @@
   };
 
   CustomSet.prototype.disjoint = function(other) {
-    if (this.data.length === 0) { return false };
+    if (this.data.length === 0) { return true };
     for (var i = 0; i < this.data.length; i++) {
       if (other.data.indexOf(this.data[i]) !== -1) {
         return false;


### PR DESCRIPTION
Closes #65 