### PR TITLE
Improve test specs on "Leap" exercise

### DIFF
--- a/leap/leap_test.spec.js
+++ b/leap/leap_test.spec.js
@@ -1,19 +1,42 @@
 var isLeapYear = require('./leap');
 
-describe("Year", function() {
-  it("a known leap year", function() {
-    expect(isLeapYear(1996)).toBe(true);
+describe("Leap year", function() {
+
+  it("is not very common", function() {
+    expect(isLeapYear(2015)).not.toBe(true);
   });
 
-  xit("any old year", function() {
-    expect(isLeapYear(1997)).not.toBe(true);
+  xit("is introduced every 4 years to adjust about a day", function() {
+    expect(isLeapYear(2016)).toBe(true);
   });
 
-  xit("turn of the 20th century", function() {
+  xit("is skipped every 100 years to remove an extra day", function() {
     expect(isLeapYear(1900)).not.toBe(true);
   });
 
-  xit("turn of the 21st century", function() {
-    expect(isLeapYear(2400)).toBe(true);
+  xit("is reintroduced every 400 years to adjust another day", function() {
+    expect(isLeapYear(2000)).toBe(true);
   });
+
+  // Feel free to enable the following tests to check some more examples
+  xdescribe("Additional example of a leap year that", function () {
+
+    it("is not a leap year", function () {
+      expect(isLeapYear(1978)).not.toBe(true);
+    });
+
+    it("is a common leap year", function () {
+      expect(isLeapYear(1992)).toBe(true);
+    });
+
+    it("is skipped every 100 years", function () {
+      expect(isLeapYear(2100)).not.toBe(true);
+    });
+
+    it("is reintroduced every 400 years", function () {
+      expect(isLeapYear(2400)).toBe(true);
+    });
+
+  });
+
 });


### PR DESCRIPTION
While solving this exercise for exercism.io I thought test specs could be improved (from my point of view, so I might be wrong). This PR tries to clarify the specs and provides some more examples of leap and non-leap years.

Specs haven't changed, but I hope texts describing them are clearer now.
