### PR TITLE
hamming: test requiring a function opposed to an object

### DIFF
--- a/hamming/example.js
+++ b/hamming/example.js
@@ -1,4 +1,4 @@
-exports.compute = function (strand1, strand2) {
+module.exports = function (strand1, strand2) {
   var len1 = strand1.length;
   var len2 = strand2.length;
 

--- a/hamming/hamming_test.spec.js
+++ b/hamming/hamming_test.spec.js
@@ -1,4 +1,4 @@
-var compute = require('./hamming').compute;
+var compute = require('./hamming');
 
 describe('Hamming', function () {
 


### PR DESCRIPTION
For more consistency. 
Most tests (at least the first few) require a function opposed to an object. There is no reason to break with this habit in this particular test.