### PR TITLE
Fix spuriously passing tests.

### DIFF
--- a/leap/leap_test.spec.js
+++ b/leap/leap_test.spec.js
@@ -3,7 +3,7 @@ var isLeapYear = require('./leap');
 describe('Leap year', function() {
 
   it('is not very common', function() {
-    expect(isLeapYear(2015)).not.toBe(true);
+    expect(isLeapYear(2015)).toBe(false);
   });
 
   xit('is introduced every 4 years to adjust about a day', function() {
@@ -11,7 +11,7 @@ describe('Leap year', function() {
   });
 
   xit('is skipped every 100 years to remove an extra day', function() {
-    expect(isLeapYear(1900)).not.toBe(true);
+    expect(isLeapYear(1900)).toBe(false);
   });
 
   xit('is reintroduced every 400 years to adjust another day', function() {
@@ -22,7 +22,7 @@ describe('Leap year', function() {
   xdescribe('Additional example of a leap year that', function () {
 
     it('is not a leap year', function () {
-      expect(isLeapYear(1978)).not.toBe(true);
+      expect(isLeapYear(1978)).toBe(false);
     });
 
     it('is a common leap year', function () {
@@ -30,7 +30,7 @@ describe('Leap year', function() {
     });
 
     it('is skipped every 100 years', function () {
-      expect(isLeapYear(2100)).not.toBe(true);
+      expect(isLeapYear(2100)).toBe(false);
     });
 
     it('is reintroduced every 400 years', function () {

--- a/pythagorean-triplet/pythagorean_triplet_test.spec.js
+++ b/pythagorean-triplet/pythagorean_triplet_test.spec.js
@@ -15,7 +15,7 @@ describe('Triplet', function () {
   });
 
   xit('can recognize a non pythagorean triplet', function () {
-    expect(new Triplet(5, 6, 7).isPythagorean()).not.toBe(true);
+    expect(new Triplet(5, 6, 7).isPythagorean()).toBe(false);
   });
 
   xit('can make triplets up to 10', function () {


### PR DESCRIPTION
This should not pass:

```javascript
module.exports = function (year) {
  return "Foo"
};
```