### PR TITLE
Add test cases for rna to dna transcription to enrich example

### DIFF
--- a/rna-transcription/example.js
+++ b/rna-transcription/example.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = toRna;
+var DnaTranscriber = function(){};
 
 var dnaToRna = {
   G: 'C',
@@ -9,8 +9,25 @@ var dnaToRna = {
   A: 'U'
 };
 
-function toRna(dna) {
+var rnaToDna = {
+  G: 'C',
+  C: 'G',
+  U: 'A',
+  A: 'T'
+};
+
+var transcribeDna = function(dna, lookupTable) {
   return dna.replace(/./g, function(dnaNucleotide) {
-    return dnaToRna[dnaNucleotide];
+    return lookupTable[dnaNucleotide];
   });
 }
+
+DnaTranscriber.prototype.toRna = function(dna) {
+  return transcribeDna(dna, dnaToRna);
+}
+
+DnaTranscriber.prototype.toDna = function(dna) {
+  return transcribeDna(dna, rnaToDna);
+}
+
+module.exports = DnaTranscriber;

--- a/rna-transcription/rna_transcription_test.spec.js
+++ b/rna-transcription/rna_transcription_test.spec.js
@@ -1,24 +1,49 @@
-var toRna = require('./rna_transcription');
+var DnaTranscriber = require('./rna_transcription');
+var dnaTranscriber = new DnaTranscriber();
 
 describe('toRna()', function() {
+
   it('transcribes cytosine to guanine', function() {
-    expect(toRna('C')).toEqual('G');
+    expect(dnaTranscriber.toRna('C')).toEqual('G');
   });
 
   xit('transcribes guanine to cytosine', function() {
-    expect(toRna('G')).toEqual('C');
+    expect(dnaTranscriber.toRna('G')).toEqual('C');
   });
 
   xit('transcribes adenine to uracil', function() {
-    expect(toRna('A')).toEqual('U');
+    expect(dnaTranscriber.toRna('A')).toEqual('U');
   });
 
   xit('transcribes thymine to adenine', function() {
-    expect(toRna('T')).toEqual('A');
+    expect(dnaTranscriber.toRna('T')).toEqual('A');
   });
 
   xit('transcribes all dna nucleotides to their rna complements', function() {
-    expect(toRna('ACGTGGTCTTAA'))
+    expect(dnaTranscriber.toRna('ACGTGGTCTTAA'))
         .toEqual('UGCACCAGAAUU');
+  });
+});
+
+xdescribe('toDna()', function() {
+  it('transcribes cytosine to guanine', function() {
+    expect(dnaTranscriber.toDna('C')).toEqual('G');
+  });
+
+  xit('transcribes guanine to cytosine', function() {
+    expect(dnaTranscriber.toDna('G')).toEqual('C');
+  });
+
+  xit('transcribes adenine to uracil', function() {
+    expect(dnaTranscriber.toDna('U')).toEqual('A');
+  });
+
+  xit('transcribes thymine to adenine', function() {
+    expect(dnaTranscriber.toDna('A')).toEqual('T');
+  });
+
+  xit('transcribes all dna nucleotides to their rna complements', function() {
+    expect(dnaTranscriber.toDna('UGAACCCGACAUG'))
+        .toEqual('ACTTGGGCTGTAC');
   });
 });


### PR DESCRIPTION
Saw that in the ruby example it consider conversion in both ways, which is not exactly the same and might make programmers consider how to remove the duplicated code.
Hope it helps!