### PR TITLE
bracket-push: Add test for proper nesting

### DIFF
--- a/bracket-push/bracket_push_test.spec.js
+++ b/bracket-push/bracket_push_test.spec.js
@@ -21,6 +21,10 @@ describe('bracket push', function() {
     expect(bracket('{[]}')).toEqual(true);
   });
 
+  xit('rejects brackets that are properly balanced but improperly nested', function() {
+    expect(bracket('{[}]')).toEqual(false);
+  });
+
   xit('checks bracket closure with deeper nesting', function() {
     expect(bracket('{[)][]}')).toEqual(false);
   });


### PR DESCRIPTION
This rules out solutions that simply count the number of open/close
brackets without regard for whether they are properly nested.

I submitted a solution (in another language track) that would have
failed this test and did not realize it until looking at others'
solutions. It would be great if I could have known before submitting,
thus I add this test.

Corresponding PR on xgo https://github.com/exercism/xgo/pull/176