### PR TITLE
Extra tests for the 'binary' exercise.

### DIFF
--- a/binary/binary.spec.js
+++ b/binary/binary.spec.js
@@ -1,8 +1,11 @@
 var Binary = require('./binary');
 
 describe('binary', function() {
+  it('0 is decimal 0', function() {
+    expect(new Binary('0').toDecimal()).toEqual(0);
+  });
 
-  it('1 is decimal 1', function() {
+  xit('1 is decimal 1', function() {
     expect(new Binary('1').toDecimal()).toEqual(1);
   });
 
@@ -30,8 +33,15 @@ describe('binary', function() {
     expect(new Binary('10001101000').toDecimal()).toEqual(1128);
   });
 
-  xit('carrot is decimal 0', function() {
+  xit('00011111 is decimal 31', function() {
+    expect(new Binary('00011111').toDecimal()).toEqual(31);
+  });
+
+  xit('invalid inputs are decimal 0', function() {
     expect(new Binary('carrot').toDecimal()).toEqual(0);
+    expect(new Binary('012').toDecimal()).toEqual(0);
+    expect(new Binary('10nope').toDecimal()).toEqual(0);
+    expect(new Binary('nope10').toDecimal()).toEqual(0);
   });
 
 });

--- a/binary/example.js
+++ b/binary/example.js
@@ -3,7 +3,11 @@
 module.exports = Binary;
 
 function Binary(binary) {
-  this.binary = parseInt(binary, 2);
+  if (binary.match(/^[01]*$/)) {
+    this.binary = parseInt(binary, 2);
+  } else {
+    this.binary = 0;
+  }
 }
 
 Binary.prototype.toDecimal = function () {


### PR DESCRIPTION
_cf. [x-common issue #95](https://github.com/exercism/x-common/issues/95)._

I've expanded the JS test for the 'binary' exercise to include the same examples as the [Ruby equivalent](https://github.com/exercism/xruby/blob/master/binary/binary_test.rb). The example solution has also been updated so it passes the new tests.

However, I'm not familiar enough with the Exercism progression to know if this is pitched at an appropriate level – that is, if students are expected to do string validation or understand the nuances of `parseInt` at this point. [JavaScript's `parseInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) is rather more flexible than solutions in other languages, and doesn't make it easy to bail out on invalid input: 

> If `parseInt` encounters a character that is not a numeral in the specified radix, it ignores it and all succeeding characters and returns the integer value parsed up to that point... If the first character cannot be converted to a number, `parseInt` returns `NaN`.

If there's a different approach you'd like me to take with this, let me know and I'll adjust this PR to suit. :)