### PR TITLE
circular-buffer: Test forced writes on non-full buffer

### DIFF
--- a/circular-buffer/circular-buffer.spec.js
+++ b/circular-buffer/circular-buffer.spec.js
@@ -82,6 +82,15 @@ describe('CircularBuffer', function() {
     expect(buffer.read).toThrow(bufferEmptyException());
   });
 
+  xit('forced writes act like write in a non-full buffer', function() {
+    var buffer = circularBuffer(2);
+    buffer.write('1');
+    buffer.forceWrite('2');
+    expect(buffer.read()).toBe('1');
+    expect(buffer.read()).toBe('2');
+    expect(buffer.read).toThrow(bufferEmptyException());
+  });
+
   xit('alternate force write and read into full buffer', function() {
     var buffer = circularBuffer(5);
     [1,2,3].map(function(i) { buffer.write(i.toString()); });

--- a/circular-buffer/example.js
+++ b/circular-buffer/example.js
@@ -22,8 +22,8 @@ function CircularBuffer(capacity) {
 
       forceWrite: function(data) {
         updateBuffer(data, function(){
-          buffer[writePoint] = data;
           if (isBufferFull()) { updateReadPoint(); }
+          buffer[writePoint] = data;
         });
       },
 


### PR DESCRIPTION
Other language tracks have been adding this:

Ruby:
https://github.com/exercism/xruby/commit/5560b7a0e032bdf4bca753d4aba4625340853d1c

Go:
https://github.com/exercism/xgo/commit/6b41d2f925a7b35140701a8290e7d9a6155ac315

Rust:
https://github.com/exercism/xrust/commit/e4990f1b0e8c9d16053012b13aaaeb03ac141383

Seems prudent for Javascript to test it as well. This will see if any
solutions are unconditionally dropping when overwriting (that would drop
elements from non-full buffers)