### PR TITLE
Test immutability of the gigasecond

### DIFF
--- a/gigasecond/gigasecond.spec.js
+++ b/gigasecond/gigasecond.spec.js
@@ -20,4 +20,10 @@ describe('Gigasecond', function() {
     expect(gs.date()).toEqual(expectedDate);
   });
 
+  xit('test 4', function() {
+    var gs = new Gigasecond(new Date(1959, 6, 19));
+    var expectedDate = new Date(1991, 2, 27);
+    gs.date();
+    expect(gs.date()).toEqual(expectedDate);
+  });
 });


### PR DESCRIPTION
I have seen submissions which mutate the original date and return that. This works for the current test suite. However, when the `date` method gets called multiple times. That solution adds another gigasecond on a date where one is already applied.

For example. One might implement the date function like this:

```
Gigasecond.prototype.date = function() {
  b = new Date(this.birthday.setSeconds(this.birthday.getSeconds() + 1000000000 ));
  return new Date(b.getFullYear(), b.getMonth(), b.getDate());
};
```

This is the incorrect behaviour that the new test case will catch:
```
var d = new Gigasecond(new Date(1995, 8, 27))
d.date()
// Sat Jun 05 2027 00:00:00 GMT+0200 (CEST)
d.date()
// Tue Feb 11 2059 00:00:00 GMT+0100 (CET)
```