### PR TITLE
fixed gigasecond to conform to metadata-- don't round dates down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # assignments
 ASSIGNMENT ?= ""
-IGNOREDIRS := "^(\.git|docs|bin|node_modules)$$"
+IGNOREDIRS := "^(\.git|docs|bin|node_modules|.idea)$$"
 ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | cut -d'/' -f2 | sort | grep -Ev $(IGNOREDIRS))
 
 # output directories

--- a/gigasecond/example.js
+++ b/gigasecond/example.js
@@ -5,14 +5,7 @@ function Gigasecond(dateOfBirth) {
 
   this.date = function() {
     var gigasecondDate = new Date(this.dateOfBirth.getTime() + 1000000000000);
-    return this.roundDownToDay(gigasecondDate);
-  };
-
-  this.roundDownToDay = function(date) {
-    date.setHours(0);
-    date.setMinutes(0);
-    date.setSeconds(0);
-    return date;
+    return gigasecondDate;
   };
 }
 

--- a/gigasecond/gigasecond.spec.js
+++ b/gigasecond/gigasecond.spec.js
@@ -2,28 +2,30 @@ var Gigasecond = require('./gigasecond');
 
 describe('Gigasecond', function() {
 
-  it('test 1', function() {
-    var gs = new Gigasecond(new Date(2011, 3, 25));
-    var expectedDate = new Date(2043, 0, 1);
+  it('tells a gigasecond anniversary since midnight', function() {
+    var gs = new Gigasecond(new Date(Date.UTC(2015, 8, 14)));
+    var expectedDate = new Date(Date.UTC(2047, 4, 23, 1, 46, 40));
     expect(gs.date()).toEqual(expectedDate);
   });
 
-  xit('test 2', function() {
-    var gs = new Gigasecond(new Date(1977, 5, 13));
-    var expectedDate = new Date(2009, 1, 19);
+  xit('tells the anniversary is next day when you are born at night', function() {
+    var gs = new Gigasecond(new Date(Date.UTC(2015, 8, 14, 23, 59, 59)));
+    var expectedDate = new Date(Date.UTC(2047, 4, 24, 1, 46, 39));
     expect(gs.date()).toEqual(expectedDate);
   });
 
-  xit('test 3', function() {
-    var gs = new Gigasecond(new Date(1959, 6, 19));
-    var expectedDate = new Date(1991, 2, 27);
+  xit('even works before 1970 (beginning of Unix epoch)', function() {
+    var gs = new Gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)));
+    var expectedDate = new Date(Date.UTC(1991, 2, 27, 7, 0, 25));
     expect(gs.date()).toEqual(expectedDate);
   });
 
-  xit('test 4', function() {
-    var gs = new Gigasecond(new Date(1959, 6, 19));
-    var expectedDate = new Date(1991, 2, 27);
+  xit('make sure calling "date" doesn\'t mutate value', function() {
+    var gs = new Gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)));
+    var expectedDate = new Date(Date.UTC(1991, 2, 27, 7, 0, 25));
     gs.date();
     expect(gs.date()).toEqual(expectedDate);
   });
 });
+
+


### PR DESCRIPTION
Addresses issue raised on xecmascript: JS track was rounding down dates to midnight, contradicting metadata for exercise.

Also add .idea to IGNOREDIRS.

@kytrinyx I can merge if this looks good.