### PR TITLE
Update setup.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -3,7 +3,7 @@
 Go through the setup instructions for JavaScript to
 install the necessary dependencies:
 
-http://help.exercism.io/getting-started-with-javascript.html
+http://exercism.io/languages/javascript
 
 ## Making the Test Suite Pass
 


### PR DESCRIPTION
Updated the URL from `http://help.exercism.io/getting-started-with-javascript.html` to `http://exercism.io/languages/javascript` since http://help.exercism.io/ has been deprecated.