### PR TITLE
Add test to catch non-numeric sorting

### DIFF
--- a/exercises/triangle/triangle.spec.js
+++ b/exercises/triangle/triangle.spec.js
@@ -77,4 +77,9 @@ describe('Triangle', function() {
     expect(triangle.kind.bind(triangle)).toThrow();
   });
 
+  xit('triangles violating triangle inequality are illegal 3', function() {
+    var triangle = new Triangle(10,1,3);
+    expect(triangle.kind.bind(triangle)).toThrow();
+  });
+
 });


### PR DESCRIPTION
A common solution to this exercise involves first sorting the sides of the triangle. This makes both validating input and determining the kind of triangle easier. However, many solutions erroneously sort the sides alphabetically (the default sort for arrays in JS is alphabetical, even if the array elements are numeric). There is already a test case (Triangle(10,10,2)) that correctly fails when determining kind with incorrectly sorted sides. The test case this PR introduces will also fail validation (triangle inequality) with incorrectly sorted sides.