### PR TITLE
Fix markdown syntax in ABOUT.md

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,13 +1,15 @@
-Javascript is a scripting language used to provide dynamic and interactive content on webpages. Also, server side JS allows the use of the same language on the server and client. Besides being fast, JavaScript provides benefits like :- 
+Javascript is a scripting language used to provide dynamic and interactive content on webpages. Also, server side JS allows the use of the same language on the server and client. Besides being fast, JavaScript provides benefits like:
+
 * Reducing server traffic by validating user input in the browser before it is sent to the server.
 * Providing immediate feedback to the site visitors so that they don't have to reload pages just to get error messages on form validations.
 * Allowing richer user interfaces with content changes on mouse hover, drag and drop gestures, and animations.
 
 Client-side JavaScript is interpreted in the browser without requiring compilation. This allows interactive content to be included in HTML pages which would otherwise be static.
 
-Server-Side JavaScript as run in NodeJS enables back-end access to databases, file systems, and servers. NodeJS is built on Google Chrome's JavaScript V8 Engine. NodeJS uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node can be a great solution for applications requiring I/O bound operations, data streaming etc. More details can be found  [here](https://nodejs.org/en/about/)
+Server-Side JavaScript as run in NodeJS enables back-end access to databases, file systems, and servers. NodeJS is built on Google Chrome's JavaScript V8 Engine. NodeJS uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node can be a great solution for applications requiring I/O bound operations, data streaming etc. More details can be found  [here](https://nodejs.org/en/about/).
 
-You should learn JavaScript because:- 
+You should learn JavaScript because:
+
 * It's easy to learn.
 * It's versatile in the sense that it's multi-paradigm supporting procedural, event based, object oriented and functional programming.
 * It's Open Source.


### PR DESCRIPTION
This fixes a layout bug on http://exercism.io/languages/javascript.

I've also tidied up the punctuation and trailing whitespace.

The Redcarpet Markdown parser requires a blank line before lists ([see this Babelmark](http://johnmacfarlane.net/babelmark2/?text=You+should+learn+JavaScript+because%3A-%0A*+It's+easy+to+learn.%0A*+It's+versatile+in+the+sense+that+it's+multi-paradigm+supporting+procedural%2C+event+based%2C+object+oriented+and+functional+programming.%0A*+It's+Open+Source.%0A*+JavaScript+programming+skills+are+in+high+demand.)), so the lists in this file were being rendered inline rather than as a `<ul>`.

The bug isn't obvious when you view the file on Github because Github's Markdown parser is more flexible about blank lines.

As a side-note, Redcarpet has a `:lax_spacing` option which you could use if this is a common problem and you don't mind the Markdown parsing being less strict.