### PR TITLE
Remove test which allows degenerate (a+b=c) triangles

### DIFF
--- a/exercises/triangle/triangle.spec.js
+++ b/exercises/triangle/triangle.spec.js
@@ -72,11 +72,6 @@ describe('Triangle', function() {
     expect(triangle.kind.bind(triangle)).toThrow();
   });
 
-  xit('edge cases of triangle inequality are in fact legal', function() {
-    var triangle = new Triangle(2,4,2);
-    expect(triangle.kind.bind(triangle)).not.toThrow();
-  });
-
   xit('triangles violating triangle inequality are illegal 2', function() {
     var triangle = new Triangle(7,3,2);
     expect(triangle.kind.bind(triangle)).toThrow();


### PR DESCRIPTION
I'm removing this test that i added after the outcome of [a discussion on the Erlang track](https://github.com/exercism/xerlang/issues/85) that concluded we should not allow 'degenerate' triangles, EG sides a,c,b where a+b=c.

