### PR TITLE
Removed test which contradicted the README.md

### DIFF
--- a/exercises/linked-list/linked-list.spec.js
+++ b/exercises/linked-list/linked-list.spec.js
@@ -42,10 +42,6 @@ describe('LinkedList', function () {
     expect(list.pop()).toBe(50);
     expect(list.shift()).toBe(30);
   });
-  xit('pops undefined when there are no elements', function () {
-    var list = new LinkedList();
-    expect(list.pop()).toBe(undefined);
-  });
   xit('can count its elements', function () {
     var list = new LinkedList();
     expect(list.count()).toBe(0);


### PR DESCRIPTION
The README.md states:
> To keep your implementation simple, the tests will not cover error conditions. 
> Specifically: pop or shift will never be called on an empty Deque

I removed the one test which did a pop() on an empty Deque anyway.