### PR TITLE
make hex characters easier to understand

### DIFF
--- a/exercises/bob/bob.spec.js
+++ b/exercises/bob/bob.spec.js
@@ -54,7 +54,13 @@ describe('Bob', function() {
   });
 
   xit('shouting with umlauts', function() {
-    // NOTE: "\xfcML\xe4\xdcTS" === "üMLäÜTS"
+    /* NOTE: \xc4 = Ä
+             \xe4 = ä
+             \xdc = Ü 
+             \xfc = ü
+       "\xfcML\xe4\xdcTS" === "üMLäÜTS"
+    */
+    
     var result = bob.hey('\xdcML\xc4\xdcTS!'); 
     expect(result).toEqual('Whoa, chill out!');
   });


### PR DESCRIPTION
This update will fix the example on the hex characters by telling the reader what each hex character is in normal text format.