### PR TITLE
CustomSet: Adds test for eql method specifically

### DIFF
--- a/exercises/custom-set/custom-set.spec.js
+++ b/exercises/custom-set/custom-set.spec.js
@@ -2,6 +2,18 @@ var CustomSet = require('./custom-set');
 
 describe('CustomSet', function() {
 
+  it('can compare equality of sets', function(){
+    var subject = new CustomSet([3, 2, 1]);
+    var duplicateSubject = new CustomSet([3, 2, 1]);
+    expect(subject.eql(duplicateSubject)).toBe(true);
+
+    var unOrderedDuplicateSubject = new CustomSet([3, 1, 2]);
+    expect(subject.eql(unOrderedDuplicateSubject)).toBe(true);
+
+    var nonDuplicateSubject = new CustomSet([2, 1]);
+    expect(subject.eql(nonDuplicateSubject)).toBe(false);
+  });
+
   it('can delete elements', function(){
     var expected = new CustomSet([1, 3]);
     var actual = new CustomSet([3, 2, 1]).delete(2);


### PR DESCRIPTION
When going through the `custom-set` exercise, I felt like the first test covered both the .eql and the .delete methods and could cause some confusion.

This PR adds a test, matching the other test styles, to specifically target the `.eql` method prior to diving into testing `.delete`