### PR TITLE
Make the test instructions more beginner-friendly

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -9,9 +9,7 @@ http://exercism.io/languages/javascript
 
 Execute the tests with:
 
-```bash
-$ jasmine-node .
-```
+    jasmine-node .
 
 In many test suites all but the first test have been skipped.
 


### PR DESCRIPTION
The github-flavored-markdown section of SETUP using the fenceposts
is completely non-obvious if you aren't familiar with markdown.

I just watched a newbie try to type in the backticks and "bash"
along with the dollar-sign.

This removes some of the clutter.