### PR TITLE
word-count: use 'constructor' as a reserved word

### DIFF
--- a/exercises/word-count/word-count.spec.js
+++ b/exercises/word-count/word-count.spec.js
@@ -59,7 +59,7 @@ describe('count()', function() {
   });
 
   xit('handles properties that exist on Object’s prototype', function() {
-    var expectedCounts = { reserved: 1, words : 1, like :1,  prototype: 1, and : 1, tostring: 1,  'ok?': 1};
-    expect(words.count('reserved words like prototype and toString ok?')).toEqual(expectedCounts);
+    var expectedCounts = { reserved: 1, words: 1, like: 1, constructor: 1, and: 1, tostring: 1, 'ok?': 1 };
+    expect(words.count('reserved words like constructor and toString ok?')).toEqual(expectedCounts);
   });
 });


### PR DESCRIPTION
As 'prototype' isn't a standard property on an object's prototype,
the test didn't actually check the case of dealing with a collision

The 'constructor' property is a standard

see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
and: http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.4

It's possible that this will break existing solutions - the reference solution is immune though