### PR TITLE
palindrome-product: fix typo in test name

### DIFF
--- a/exercises/palindrome-products/palindrome-products.spec.js
+++ b/exercises/palindrome-products/palindrome-products.spec.js
@@ -15,7 +15,7 @@ describe('Palindrome', function() {
     expect(orderedLargestFactors).toEqual([[1, 9], [3, 3]]);
   });
 
-  xit('largets palindrome from double digit factors', function() {
+  xit('largest palindrome from double digit factors', function() {
     var palindromes = new Palindromes({ maxFactor: 99, minFactor: 10 });
     palindromes.generate();
 


### PR DESCRIPTION
Fixes a small typo I noticed while reviewing the spec