### PR TITLE
Improve instructions for Windows and Mac OS X users

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,14 +1,25 @@
-**Windows and OS X users**: Install [Node.js](http://nodejs.org/) [via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager). Windows users can use Visual Studio, see below.
+## Installing Node.js
 
-**Linux users**: [Joyent maintains a document][linstall] that details how to get Node.js installed for a wide range of distributions and package managers.
+There are at least two common options to run JavaScript code: the browsers and [Node.js](http://nodejs.org/). Here we are going to use Node.js to run our JavaScript code. Let's see how to install Node.js locally:
 
-[linstall]: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager
+**Windows users**: find official installers on [Node.js downloads](https://nodejs.org/en/download/). Choose the LTS (long term support) version. It will install Node.js on your machine as well as `npm` (that stands for Node Package Manager), a tool that helps installing applications that run on top of Node.js.
 
-Install `jasmine-node`:
+**Mac OS X users**: same as Windows users, you will find official installers on [Node.js downloads](https://nodejs.org/en/download/). Choose the LTS version. It will install Node.js and `npm` on your machine.
+
+**Linux users**: there are binaries for `node` and `npm` tools on the Node.js downloads page, but the recommended way to install them on a Linux machine is via a package manager. As of writing this, the recommended version of Node.js to install is 4.x. To install it on a Debian or Ubuntu Linux distribuion just execute these commands:
+
+    curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+
+If you are using a different distribution or package manager, you can find a complete list of supported ones on the official documentation page: [Installing Node.js via package manager](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions).
+
+## Installing additional tools
+
+The next step is to install `jasmine-node` globally so that you can run JavaScript tests:
 
     npm install jasmine-node -g
 
-Depending on your setup, you may need super user privileges to install an NPM module globally. This is the case if you've used the official installer linked to above. If NPM gives you an error saying you don't have access, add `sudo` to the command above:
+Depending on your setup, you may need super user privileges to install an `npm` module globally. This is the case if you've used the official installer linked to above. If `npm` gives you an error saying you don't have access, add `sudo` to the command above:
 
     sudo npm install jasmine-node -g
 


### PR DESCRIPTION
Addresses #194.

There are separated and more detailed instructions for Windows, Mac and Linux platforms.

I hope it is clear that Node.js comes with the `npm` tool and that exercism users need to install `jasmine-node` to run tests.