### PR TITLE
Update custom set test order

### DIFF
--- a/exercises/custom-set/custom-set.spec.js
+++ b/exercises/custom-set/custom-set.spec.js
@@ -2,6 +2,151 @@ var CustomSet = require('./custom-set');
 
 describe('CustomSet', function() {
 
+  xit('can test for no members', function() {
+    var actual = new CustomSet().empty();
+    expect(actual).toBe(true);
+
+    var actual2 = new CustomSet([1]).empty();
+    expect(actual2).toBe(false);
+  });
+
+  xit('can test for a member', function() {
+    var actual = new CustomSet().contains(1);
+    expect(actual).toBe(false);
+
+    var actual2 = new CustomSet([1, 2, 3]).contains(1);
+    expect(actual2).toBe(true);
+
+    var actual3 = new CustomSet([1, 2, 3]).contains(4);
+    expect(actual3).toBe(false);
+  });
+
+  xit('can test for subsets', function() {
+    var actual = new CustomSet().subset(new CustomSet());
+    expect(actual).toBe(true);
+
+    var actual2 = new CustomSet([1]).subset(new CustomSet());
+    expect(actual2).toBe(true);
+
+    var actual3 = new CustomSet().subset(new CustomSet([1]));
+    expect(actual3).toBe(false);
+
+    var actual4 = new CustomSet([1, 2, 3]).subset(new CustomSet([1, 2, 3]));
+    expect(actual4).toBe(true);
+
+    var actual5 = new CustomSet([4, 1, 2, 3]).subset(new CustomSet([1, 2, 3]));
+    expect(actual5).toBe(true);
+
+    var actual6 = new CustomSet([4, 1, 3]).subset(new CustomSet([1, 2, 3]));
+    expect(actual6).toBe(false);
+  });
+
+  xit('can test disjoint', function() {
+    var actual = new CustomSet().disjoint(new CustomSet());
+    expect(actual).toBe(true);
+
+    var actual2 = new CustomSet().disjoint(new CustomSet([1]));
+    expect(actual2).toBe(true);
+
+    var actual3 = new CustomSet([1]).disjoint(new CustomSet());
+    expect(actual3).toBe(true);
+
+    var actual4 = new CustomSet([1, 2]).disjoint(new CustomSet([2, 3]));
+    expect(actual4).toBe(false);
+
+    var actual5 = new CustomSet([1, 2]).disjoint(new CustomSet([3, 4]));
+    expect(actual5).toBe(true);
+  });
+
+  xit('can test for equality', function () {
+    var actual = new CustomSet().eql(new CustomSet());
+    expect(actual).toBe(true);
+
+    var actual2 = new CustomSet().eql(new CustomSet([1, 2, 3]));
+    expect(actual2).toBe(false);
+
+    var actual3 = new CustomSet([1, 2, 3]).eql(new CustomSet());
+    expect(actual3).toBe(false);
+
+    var actual4 = new CustomSet([1, 2]).eql(new CustomSet([2, 1]));
+    expect(actual4).toBe(true);
+
+    var actual5 = new CustomSet([1, 2, 3]).eql(new CustomSet([1, 2, 4]));
+    expect(actual5).toBe(false);
+  });
+
+  xit('can add a member', function() {
+    var actual = new CustomSet().add(3);
+    var expected = new CustomSet([3]);
+    expect(actual.eql(expected)).toBe(true);
+
+    var actual2 = new CustomSet([1, 2, 4]).add(3);
+    var expected2 = new CustomSet([1, 2, 3, 4]);
+    expect(actual2.eql(expected2)).toBe(true);
+
+    var actual3 = new CustomSet([1, 2, 3]).add(3);
+    var expected3 = new CustomSet([1, 2, 3]);
+    expect(actual3.eql(expected3)).toBe(true);
+  });
+
+  xit('can check for intersection', function() {
+    var actual = new CustomSet().intersection(new CustomSet());
+    var expected = new CustomSet();
+    expect(actual.eql(expected)).toBe(true);
+
+    var actual2 = new CustomSet().intersection(new CustomSet([3, 2, 5]));
+    var expected2 = new CustomSet();
+    expect(actual2.eql(expected2)).toBe(true);
+
+    var actual3 = new CustomSet([1, 2, 3, 4]).intersection(new CustomSet());
+    var expected3 = new CustomSet();
+    expect(actual3.eql(expected3)).toBe(true);
+
+    var actual4 = new CustomSet([1, 2, 3]).intersection(new CustomSet([4, 5, 6]));
+    var expected4 = new CustomSet();
+    expect(actual4.eql(expected4)).toBe(true);
+
+    var actual5 = new CustomSet([1, 2, 3, 4]).intersection(new CustomSet([3, 2, 5]));
+    var expected5 = new CustomSet([2, 3]);
+    expect(actual5.eql(expected5)).toBe(true);
+  });
+
+  xit('can check for difference', function(){
+    var actual = new CustomSet().difference(new CustomSet());
+    var expected = new CustomSet();
+    expect(actual.eql(expected)).toBe(true);
+
+    var actual2 = new CustomSet().difference(new CustomSet([3, 2, 5]));
+    var expected2 = new CustomSet();
+    expect(actual2.eql(expected2)).toBe(true);
+
+    var actual3 = new CustomSet([1, 2, 3, 4]).difference(new CustomSet());
+    var expected3 = new CustomSet([1, 2, 3, 4]);
+    expect(actual3.eql(expected3)).toBe(true);
+
+    var actual4 = new CustomSet([3, 2, 1]).difference(new CustomSet([2, 4]));
+    var expected4 = new CustomSet([1, 3]);
+    expect(actual4.eql(expected4)).toBe(true);
+  });
+
+  xit('can test for union', function() {
+    var actual = new CustomSet().union(new CustomSet());
+    var expected = new CustomSet();
+    expect(actual.eql(expected)).toBe(true);
+
+    var actual2 = new CustomSet().union(new CustomSet([2]));
+    var expected2 = new CustomSet([2]);
+    expect(actual2.eql(expected2)).toBe(true);
+
+    var actual3 = new CustomSet([1, 3]).union(new CustomSet());
+    var expected3 = new CustomSet([1, 3]);
+    expect(actual3.eql(expected3)).toBe(true);
+
+    var actual4 = new CustomSet([1, 3]).union(new CustomSet([2, 3]));
+    var expected4 = new CustomSet([3, 2, 1]);
+    expect(actual4.eql(expected4)).toBe(true);
+  });
+
   it('can delete elements', function(){
     var expected = new CustomSet([1, 3]);
     var actual = new CustomSet([3, 2, 1]).delete(2);
@@ -12,56 +157,12 @@ describe('CustomSet', function() {
     expect(actual2.eql(expected2)).toBe(true);
   });
 
-  xit('can check for difference', function(){
-    var expected = new CustomSet([1, 3]);
-    var actual = new CustomSet([3, 2, 1]).difference(new CustomSet([2, 4]));
-    expect(actual.eql(expected)).toBe(true);
-    var expected2 = new CustomSet([1, 2, 3]);
-    var actual2 = new CustomSet([1, 2, 3]).difference(new CustomSet([4]));
-    expect(actual2.eql(expected2)).toBe(true);
-  });
-
-  xit('can test disjoint', function() {
-    var actual = new CustomSet([1, 2]).disjoint(new CustomSet([3, 4]));
-    expect(actual).toBe(true);
-    var actual2 = new CustomSet([1, 2]).disjoint(new CustomSet([2, 3]));
-    expect(actual2).toBe(false);
-    var actual3 = new CustomSet().disjoint(new CustomSet());
-    expect(actual3).toBe(true);
-  });
-
   xit('can be emptied', function() {
-    var actual = new CustomSet([1, 2]).empty();
+    var actual = new CustomSet([1, 2]).clear();
     var expected = new CustomSet();
     expect(actual.eql(expected)).toBe(true);
-    var actual2 = new CustomSet().empty();
+    var actual2 = new CustomSet().clear();
     var expected2 = new CustomSet();
-    expect(actual2.eql(expected2)).toBe(true);
-  });
-
-  xit('can check for intersection', function() {
-    var actual = new CustomSet(['a', 'b', 'c']).intersection(new CustomSet(['a', 'c', 'd']));
-    var expected = new CustomSet(['a', 'c']);
-    expect(actual.eql(expected)).toBe(true);
-
-    var actual2 = new CustomSet([1, 2, 3]).intersection(new CustomSet([3, 5, 4]));
-    var expected2 = new CustomSet([3]);
-    expect(actual2.eql(expected2)).toBe(true);
-  });
-
-  xit('can test for a member', function() {
-    var actual = new CustomSet([1, 2, 3]).member(2);
-    expect(actual).toBe(true);
-    var actual2 = new CustomSet([1, 2, 3]).member(4);
-    expect(actual2).toBe(false);
-  });
-
-  xit('can add a member with put', function() {
-    var actual = new CustomSet([1, 2, 4]).put(3);
-    var expected = new CustomSet([1, 2, 3, 4]);
-    expect(actual.eql(expected)).toBe(true);
-    var actual2 = new CustomSet([1, 2, 3]).put(3);
-    var expected2 = new CustomSet([1, 2, 3]);
     expect(actual2.eql(expected2)).toBe(true);
   });
 
@@ -74,19 +175,6 @@ describe('CustomSet', function() {
     expect(actual3).toBe(3);
   });
 
-  xit('can test for subsets', function() {
-    var actual = new CustomSet([1, 2, 3]).subset(new CustomSet([1, 2, 3]));
-    expect(actual).toBe(true);
-    var actual2 = new CustomSet([4, 1, 2, 3]).subset(new CustomSet([1, 2, 3]));
-    expect(actual2).toBe(true);
-    var actual3 = new CustomSet([4, 1, 3]).subset(new CustomSet([1, 2, 3]));
-    expect(actual3).toBe(false);
-    var actual4 = new CustomSet([4, 1, 3]).subset(new CustomSet());
-    expect(actual4).toBe(true);
-    var actual5 = new CustomSet().subset(new CustomSet());
-    expect(actual5).toBe(true);
-  });
-
   xit('can give back a list', function() {
     var actual = new CustomSet().toList();
     var expected = [];
@@ -97,21 +185,6 @@ describe('CustomSet', function() {
     var actual3 = new CustomSet([3, 1, 2, 1]).toList();
     var expected3 = [1, 2, 3];
     expect(actual3.sort()).toEqual(expected3);
-  });
-
-  xit('can test for union', function() {
-    var actual = new CustomSet([1, 3]).union(new CustomSet([2]));
-    var expected = new CustomSet([3, 2, 1]);
-    expect(actual.eql(expected)).toBe(true);
-    var actual2 = new CustomSet([1, 3]).union(new CustomSet([2, 3]));
-    var expected2 = new CustomSet([3, 2, 1]);
-    expect(actual2.eql(expected2)).toBe(true);
-    var actual3 = new CustomSet([1, 3]).union(new CustomSet());
-    var expected3 = new CustomSet([3, 1]);
-    expect(actual3.eql(expected3)).toBe(true);
-    var actual4 = new CustomSet().union(new CustomSet());
-    var expected4 = new CustomSet();
-    expect(actual4.eql(expected4)).toBe(true);
   });
 
 });

--- a/exercises/custom-set/example.js
+++ b/exercises/custom-set/example.js
@@ -6,6 +6,10 @@
     this.data = inputData || [];
   };
 
+  CustomSet.prototype.empty = function() {
+    return this.data.length === 0;
+  };
+
   CustomSet.prototype.delete = function(element) {
     var index = this.data.indexOf(element);
     if (index !== -1) {
@@ -36,7 +40,7 @@
     return true;
   };
 
-  CustomSet.prototype.empty = function() {
+  CustomSet.prototype.clear = function() {
     return new CustomSet([]);
   };
 
@@ -52,11 +56,11 @@
     return new CustomSet(result);
   };
 
-  CustomSet.prototype.member = function(datum) {
+  CustomSet.prototype.contains = function(datum) {
     return this.data.indexOf(datum) !== -1;
   };
 
-  CustomSet.prototype.put = function(datum) {
+  CustomSet.prototype.add = function(datum) {
     if (this.data.indexOf(datum) === -1) {
       this.data.push(datum);
     }
@@ -101,8 +105,8 @@
       return false;
     }
 
-    for (var i = 0; i < this.length; i++) {
-      if (thisData[i] !== otherData[i]) {
+    for (var i = 0; i < thisData.length; i++) {
+      if (thisData[i] !== thatData[i]) {
         return false;
       }
     }


### PR DESCRIPTION
fixes #283

Note that I've done this as 2 commits:

Commit 1 does not break existing solutions and does as much as possible to conform to the canonical tests. This also uncovered a bug in the example solution, which this fixes.

Commit 2 will break existing solutions, as it changes #empty to have the meaning from the canonical tests, and renames the existing method to #clear

The non-canonical tests for this track have been left (they are positioned after the canonical tests)

I've stayed with the style of the test suite to keep things consistent

Happy to discuss, squash or change any of this!