### PR TITLE
modified gigasecond assignment to use a getDate method

### DIFF
--- a/exercises/gigasecond/example.js
+++ b/exercises/gigasecond/example.js
@@ -3,7 +3,7 @@ function Gigasecond(dateOfBirth) {
 
   this.dateOfBirth = dateOfBirth;
 
-  this.date = function() {
+  this.getDate = function() {
     var gigasecondDate = new Date(this.dateOfBirth.getTime() + 1000000000000);
     return gigasecondDate;
   };

--- a/exercises/gigasecond/gigasecond.spec.js
+++ b/exercises/gigasecond/gigasecond.spec.js
@@ -5,27 +5,25 @@ describe('Gigasecond', function() {
   it('tells a gigasecond anniversary since midnight', function() {
     var gs = new Gigasecond(new Date(Date.UTC(2015, 8, 14)));
     var expectedDate = new Date(Date.UTC(2047, 4, 23, 1, 46, 40));
-    expect(gs.date()).toEqual(expectedDate);
+    expect(gs.getDate()).toEqual(expectedDate);
   });
 
   xit('tells the anniversary is next day when you are born at night', function() {
     var gs = new Gigasecond(new Date(Date.UTC(2015, 8, 14, 23, 59, 59)));
     var expectedDate = new Date(Date.UTC(2047, 4, 24, 1, 46, 39));
-    expect(gs.date()).toEqual(expectedDate);
+    expect(gs.getDate()).toEqual(expectedDate);
   });
 
   xit('even works before 1970 (beginning of Unix epoch)', function() {
     var gs = new Gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)));
     var expectedDate = new Date(Date.UTC(1991, 2, 27, 7, 0, 25));
-    expect(gs.date()).toEqual(expectedDate);
+    expect(gs.getDate()).toEqual(expectedDate);
   });
 
   xit('make sure calling "date" doesn\'t mutate value', function() {
     var gs = new Gigasecond(new Date(Date.UTC(1959, 6, 19, 5, 13, 45)));
     var expectedDate = new Date(Date.UTC(1991, 2, 27, 7, 0, 25));
-    gs.date();
-    expect(gs.date()).toEqual(expectedDate);
+    gs.getDate();
+    expect(gs.getDate()).toEqual(expectedDate);
   });
 });
-
-


### PR DESCRIPTION
Given a user writes a solution to the Gigasecond problem using the Pseudoclassical method:
```
var Gigasecond = function(date) {
  this.dob = date;
};

Gigasecond.prototype.date = function () {
  var gigasecondDate = new Date(this.dob.getTime() + 1000000000000);
  return gigasecondDate;
};

module.exports = Gigasecond;
```

the spec will fail on line 8 with the error of **TypeError: gs.date is not a function**.

line 8 of gigasecond.spec.js
```
expect(gs.date()).toEqual(expectedDate);
```

I'm not 100% sure why but if all occurrences of *gs.date()* are replaced with something like *gs.getDate()* this problem doesn't occur. I assume it is because *date* is a reserved word in JavaScript or something similar. I would suggest making this change because users are given stub files from the first exercise using the Pseudoclassical method of writing JavaScript; so when it fails at this exercise I can see people getting frustrated.

[this would be a clear example of user getting burned on this.](http://exercism.io/submissions/3dbb2f7491944d048ab4eff7cddb24f6) You can see that he tried the way that has been shown for all previous methods commented it out then did it another way.