### PR TITLE
beer-song: Add test case for 2 bottles.

### DIFF
--- a/exercises/beer-song/beer-song.spec.js
+++ b/exercises/beer-song/beer-song.spec.js
@@ -8,6 +8,11 @@ describe('BeerSong', function() {
     expect(song.verse(8)).toEqual(expected);
   });
 
+  xit('handles 2 bottles', function() {
+    var expected = '2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n';
+    expect(song.verse(2)).toEqual(expected);
+  });
+
   xit('handles 1 bottle', function() {
     var expected = '1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n';
     expect(song.verse(1)).toEqual(expected);


### PR DESCRIPTION
An isolated test of the 2 bottle case would help highlight that it is a special case. If the 2 bottle case is not called out when 1 and 0 are, the error will not be caught until the final test.