### PR TITLE
custom-set: exercise generator

### DIFF
--- a/exercises/custom-set/custom-set.spec.js
+++ b/exercises/custom-set/custom-set.spec.js
@@ -2,159 +2,205 @@ var CustomSet = require('./custom-set');
 
 describe('CustomSet', function() {
 
-  it('can test for no members', function() {
+  it('sets with no elements are empty', function() {
     var actual = new CustomSet().empty();
     expect(actual).toBe(true);
-
-    var actual2 = new CustomSet([1]).empty();
-    expect(actual2).toBe(false);
   });
 
-  xit('can test for a member', function() {
+  xit('sets with elements are not empty', function() {
+    var actual = new CustomSet([1]).empty();
+    expect(actual).toBe(false);
+  });
+
+  xit('nothing is contained in an empty set', function() {
     var actual = new CustomSet().contains(1);
     expect(actual).toBe(false);
-
-    var actual2 = new CustomSet([1, 2, 3]).contains(1);
-    expect(actual2).toBe(true);
-
-    var actual3 = new CustomSet([1, 2, 3]).contains(4);
-    expect(actual3).toBe(false);
   });
 
-  xit('can test for subsets', function() {
+  xit('when the element is in the set', function() {
+    var actual = new CustomSet([1, 2, 3]).contains(1);
+    expect(actual).toBe(true);
+  });
+
+  xit('when the element is not in the set', function() {
+    var actual = new CustomSet([1, 2, 3]).contains(4);
+    expect(actual).toBe(false);
+  });
+
+  xit('empty set is a subset of another empty set', function() {
     var actual = new CustomSet().subset(new CustomSet());
     expect(actual).toBe(true);
-
-    var actual2 = new CustomSet([1]).subset(new CustomSet());
-    expect(actual2).toBe(true);
-
-    var actual3 = new CustomSet().subset(new CustomSet([1]));
-    expect(actual3).toBe(false);
-
-    var actual4 = new CustomSet([1, 2, 3]).subset(new CustomSet([1, 2, 3]));
-    expect(actual4).toBe(true);
-
-    var actual5 = new CustomSet([4, 1, 2, 3]).subset(new CustomSet([1, 2, 3]));
-    expect(actual5).toBe(true);
-
-    var actual6 = new CustomSet([4, 1, 3]).subset(new CustomSet([1, 2, 3]));
-    expect(actual6).toBe(false);
   });
 
-  xit('can test disjoint', function() {
+  xit('empty set is a subset of non-empty set', function() {
+    var actual = new CustomSet([1]).subset(new CustomSet());
+    expect(actual).toBe(true);
+  });
+
+  xit('non-empty set is not a subset of empty set', function() {
+    var actual = new CustomSet().subset(new CustomSet([1]));
+    expect(actual).toBe(false);
+  });
+
+  xit('set is a subset of set with exact same elements', function() {
+    var actual = new CustomSet([1, 2, 3]).subset(new CustomSet([1, 2, 3]));
+    expect(actual).toBe(true);
+  });
+
+  xit('set is a subset of larger set with same elements', function() {
+    var actual = new CustomSet([4, 1, 2, 3]).subset(new CustomSet([1, 2, 3]));
+    expect(actual).toBe(true);
+  });
+
+  xit('set is not a subset of set that does not contain its elements', function() {
+    var actual = new CustomSet([4, 1, 3]).subset(new CustomSet([1, 2, 3]));
+    expect(actual).toBe(false);
+  });
+
+  xit('the empty set is disjoint with itself', function() {
     var actual = new CustomSet().disjoint(new CustomSet());
     expect(actual).toBe(true);
-
-    var actual2 = new CustomSet().disjoint(new CustomSet([1]));
-    expect(actual2).toBe(true);
-
-    var actual3 = new CustomSet([1]).disjoint(new CustomSet());
-    expect(actual3).toBe(true);
-
-    var actual4 = new CustomSet([1, 2]).disjoint(new CustomSet([2, 3]));
-    expect(actual4).toBe(false);
-
-    var actual5 = new CustomSet([1, 2]).disjoint(new CustomSet([3, 4]));
-    expect(actual5).toBe(true);
   });
 
-  xit('can test for equality', function () {
+  xit('empty set is disjoint with non-empty set', function() {
+    var actual = new CustomSet().disjoint(new CustomSet([1]));
+    expect(actual).toBe(true);
+  });
+
+  xit('non-empty set is disjoint with empty set', function() {
+    var actual = new CustomSet([1]).disjoint(new CustomSet());
+    expect(actual).toBe(true);
+  });
+
+  xit('sets are not disjoint if they share an element', function() {
+    var actual = new CustomSet([1, 2]).disjoint(new CustomSet([2, 3]));
+    expect(actual).toBe(false);
+  });
+
+  xit('sets are disjoint if they share no elements', function() {
+    var actual = new CustomSet([1, 2]).disjoint(new CustomSet([3, 4]));
+    expect(actual).toBe(true);
+  });
+
+  xit('empty sets are equal', function() {
     var actual = new CustomSet().eql(new CustomSet());
     expect(actual).toBe(true);
-
-    var actual2 = new CustomSet().eql(new CustomSet([1, 2, 3]));
-    expect(actual2).toBe(false);
-
-    var actual3 = new CustomSet([1, 2, 3]).eql(new CustomSet());
-    expect(actual3).toBe(false);
-
-    var actual4 = new CustomSet([1, 2]).eql(new CustomSet([2, 1]));
-    expect(actual4).toBe(true);
-
-    var actual5 = new CustomSet([1, 2, 3]).eql(new CustomSet([1, 2, 4]));
-    expect(actual5).toBe(false);
   });
 
-  xit('can add a member', function() {
+  xit('empty set is not equal to non-empty set', function() {
+    var actual = new CustomSet().eql(new CustomSet([1, 2, 3]));
+    expect(actual).toBe(false);
+  });
+
+  xit('non-empty set is not equal to empty set', function() {
+    var actual = new CustomSet([1, 2, 3]).eql(new CustomSet());
+    expect(actual).toBe(false);
+  });
+
+  xit('sets with the same elements are equal', function() {
+    var actual = new CustomSet([1, 2]).eql(new CustomSet([2, 1]));
+    expect(actual).toBe(true);
+  });
+
+  xit('sets with different elements are not equal', function() {
+    var actual = new CustomSet([1, 2, 3]).eql(new CustomSet([1, 2, 4]));
+    expect(actual).toBe(false);
+  });
+
+  xit('add to empty set', function() {
     var actual = new CustomSet().add(3);
     var expected = new CustomSet([3]);
     expect(actual.eql(expected)).toBe(true);
-
-    var actual2 = new CustomSet([1, 2, 4]).add(3);
-    var expected2 = new CustomSet([1, 2, 3, 4]);
-    expect(actual2.eql(expected2)).toBe(true);
-
-    var actual3 = new CustomSet([1, 2, 3]).add(3);
-    var expected3 = new CustomSet([1, 2, 3]);
-    expect(actual3.eql(expected3)).toBe(true);
   });
 
-  xit('can check for intersection', function() {
+  xit('add to non-empty set', function() {
+    var actual = new CustomSet([1, 2, 4]).add(3);
+    var expected = new CustomSet([1, 2, 3, 4]);
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('adding an existing element does not change the set', function() {
+    var actual = new CustomSet([1, 2, 3]).add(3);
+    var expected = new CustomSet([1, 2, 3]);
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('intersection of two empty sets is an empty set', function() {
     var actual = new CustomSet().intersection(new CustomSet());
     var expected = new CustomSet();
     expect(actual.eql(expected)).toBe(true);
-
-    var actual2 = new CustomSet().intersection(new CustomSet([3, 2, 5]));
-    var expected2 = new CustomSet();
-    expect(actual2.eql(expected2)).toBe(true);
-
-    var actual3 = new CustomSet([1, 2, 3, 4]).intersection(new CustomSet());
-    var expected3 = new CustomSet();
-    expect(actual3.eql(expected3)).toBe(true);
-
-    var actual4 = new CustomSet([1, 2, 3]).intersection(new CustomSet([4, 5, 6]));
-    var expected4 = new CustomSet();
-    expect(actual4.eql(expected4)).toBe(true);
-
-    var actual5 = new CustomSet([1, 2, 3, 4]).intersection(new CustomSet([3, 2, 5]));
-    var expected5 = new CustomSet([2, 3]);
-    expect(actual5.eql(expected5)).toBe(true);
   });
 
-  xit('can check for difference', function(){
+  xit('intersection of an empty set and non-empty set is an empty set', function() {
+    var actual = new CustomSet().intersection(new CustomSet([3, 2, 5]));
+    var expected = new CustomSet();
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('intersection of a non-empty set and an empty set is an empty set', function() {
+    var actual = new CustomSet([1, 2, 3, 4]).intersection(new CustomSet());
+    var expected = new CustomSet();
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('intersection of two sets with no shared elements is an empty set', function() {
+    var actual = new CustomSet([1, 2, 3]).intersection(new CustomSet([4, 5, 6]));
+    var expected = new CustomSet();
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('intersection of two sets with shared elements is a set of the shared elements', function() {
+    var actual = new CustomSet([1, 2, 3, 4]).intersection(new CustomSet([3, 2, 5]));
+    var expected = new CustomSet([2, 3]);
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('difference of two empty sets is an empty set', function() {
     var actual = new CustomSet().difference(new CustomSet());
     var expected = new CustomSet();
     expect(actual.eql(expected)).toBe(true);
-
-    var actual2 = new CustomSet().difference(new CustomSet([3, 2, 5]));
-    var expected2 = new CustomSet();
-    expect(actual2.eql(expected2)).toBe(true);
-
-    var actual3 = new CustomSet([1, 2, 3, 4]).difference(new CustomSet());
-    var expected3 = new CustomSet([1, 2, 3, 4]);
-    expect(actual3.eql(expected3)).toBe(true);
-
-    var actual4 = new CustomSet([3, 2, 1]).difference(new CustomSet([2, 4]));
-    var expected4 = new CustomSet([1, 3]);
-    expect(actual4.eql(expected4)).toBe(true);
   });
 
-  xit('can test for union', function() {
+  xit('difference of empty set and non-empty set is an empty set', function() {
+    var actual = new CustomSet().difference(new CustomSet([3, 2, 5]));
+    var expected = new CustomSet();
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('difference of a non-empty set and an empty set is the non-empty set', function() {
+    var actual = new CustomSet([1, 2, 3, 4]).difference(new CustomSet());
+    var expected = new CustomSet([1, 2, 3, 4]);
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('difference of two non-empty sets is a set of elements that are only in the first set', function() {
+    var actual = new CustomSet([3, 2, 1]).difference(new CustomSet([2, 4]));
+    var expected = new CustomSet([1, 3]);
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('union of empty sets is an empty set', function() {
     var actual = new CustomSet().union(new CustomSet());
     var expected = new CustomSet();
     expect(actual.eql(expected)).toBe(true);
-
-    var actual2 = new CustomSet().union(new CustomSet([2]));
-    var expected2 = new CustomSet([2]);
-    expect(actual2.eql(expected2)).toBe(true);
-
-    var actual3 = new CustomSet([1, 3]).union(new CustomSet());
-    var expected3 = new CustomSet([1, 3]);
-    expect(actual3.eql(expected3)).toBe(true);
-
-    var actual4 = new CustomSet([1, 3]).union(new CustomSet([2, 3]));
-    var expected4 = new CustomSet([3, 2, 1]);
-    expect(actual4.eql(expected4)).toBe(true);
   });
 
-  xit('can delete elements', function(){
-    var expected = new CustomSet([1, 3]);
-    var actual = new CustomSet([3, 2, 1]).delete(2);
+  xit('union of an empty set and non-empty set is the non-empty set', function() {
+    var actual = new CustomSet().union(new CustomSet([2]));
+    var expected = new CustomSet([2]);
     expect(actual.eql(expected)).toBe(true);
+  });
 
-    var expected2 = new CustomSet([1, 2, 3]);
-    var actual2 = new CustomSet([3, 2, 1]).delete(4);
-    expect(actual2.eql(expected2)).toBe(true);
+  xit('union of a non-empty set and empty set is the non-empty set', function() {
+    var actual = new CustomSet([1, 3]).union(new CustomSet());
+    var expected = new CustomSet([1, 3]);
+    expect(actual.eql(expected)).toBe(true);
+  });
+
+  xit('union of non-empty sets contains all unique elements', function() {
+    var actual = new CustomSet([1, 3]).union(new CustomSet([2, 3]));
+    var expected = new CustomSet([3, 2, 1]);
+    expect(actual.eql(expected)).toBe(true);
   });
 
   xit('can be emptied', function() {

--- a/exercises/custom-set/example-gen.js
+++ b/exercises/custom-set/example-gen.js
@@ -1,0 +1,200 @@
+/**
+ * README
+ *
+ * Generates the custom-set exercise spec from the test metadata in x-common
+ *
+ * Prerequisites:
+ *
+ *     - Node.js v6 or higher (for destructuring and template literals)
+ *
+ *     - x-common and xjavascript checked out into the same parent directory
+ *
+ *     - x-common up to date
+ *
+ * Run with:
+ *
+ *     node example-gen.js
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var EXERCISE_METADATA_ROOT = '../../../x-common/exercises';
+var METADATA_FILE_NAME = 'canonical-data.json';
+var METADATA_COMMENT_KEY = '#';
+var EXERCISE_DIR_NAME = 'custom-set';
+var SPEC_FILE_NAME = 'custom-set.spec.js';
+
+var TEST_BODY_TEMPLATES = {
+  empty: function ({set, expected}) {
+    return (
+    `var actual = new CustomSet(${array(set)}).empty();
+    expect(actual).toBe(${expected});`);
+  },
+
+  contains: function ({set, element, expected}) {
+    return (
+    `var actual = new CustomSet(${array(set)}).contains(${element});
+    expect(actual).toBe(${expected});`);
+  },
+
+  subset: function ({set1, set2, expected}) {
+    return (
+    `var actual = new CustomSet(${array(set2)}).subset(new CustomSet(${array(set1)}));
+    expect(actual).toBe(${expected});`);
+  },
+
+  disjoint: function ({set1, set2, expected}) {
+    return (
+    `var actual = new CustomSet(${array(set1)}).disjoint(new CustomSet(${array(set2)}));
+    expect(actual).toBe(${expected});`);
+  },
+
+  equal: function ({set1, set2, expected}) {
+    return (
+    `var actual = new CustomSet(${array(set1)}).eql(new CustomSet(${array(set2)}));
+    expect(actual).toBe(${expected});`);
+  },
+
+  add: function ({set, element, expected}) {
+    return (
+    `var actual = new CustomSet(${array(set)}).add(${element});
+    var expected = new CustomSet(${array(expected)});
+    expect(actual.eql(expected)).toBe(true);`);
+  },
+
+  intersection: function ({set1, set2, expected}) {
+    return (
+    `var actual = new CustomSet(${array(set1)}).intersection(new CustomSet(${array(set2)}));
+    var expected = new CustomSet(${array(expected)});
+    expect(actual.eql(expected)).toBe(true);`);
+  },
+
+  difference: function ({set1, set2, expected}) {
+    return (
+    `var actual = new CustomSet(${array(set1)}).difference(new CustomSet(${array(set2)}));
+    var expected = new CustomSet(${array(expected)});
+    expect(actual.eql(expected)).toBe(true);`);
+  },
+
+  union: function ({set1, set2, expected}) {
+    return (
+    `var actual = new CustomSet(${array(set1)}).union(new CustomSet(${array(set2)}));
+    var expected = new CustomSet(${array(expected)});
+    expect(actual.eql(expected)).toBe(true);`);
+  }
+}
+
+var NON_CANONICAL_TESTS = `
+  xit('can be emptied', function() {
+    var actual = new CustomSet([1, 2]).clear();
+    var expected = new CustomSet();
+    expect(actual.eql(expected)).toBe(true);
+    var actual2 = new CustomSet().clear();
+    var expected2 = new CustomSet();
+    expect(actual2.eql(expected2)).toBe(true);
+  });
+
+  xit('knows its size', function() {
+    var actual = new CustomSet().size();
+    expect(actual).toBe(0);
+    var actual2 = new CustomSet([1, 2, 3]).size();
+    expect(actual2).toBe(3);
+    var actual3 = new CustomSet([1, 2, 3, 2]).size();
+    expect(actual3).toBe(3);
+  });
+
+  xit('can give back a list', function() {
+    var actual = new CustomSet().toList();
+    var expected = [];
+    expect(actual.sort()).toEqual(expected);
+    var actual2 = new CustomSet([3, 1, 2]).toList();
+    var expected2 = [1, 2, 3];
+    expect(actual2.sort()).toEqual(expected2);
+    var actual3 = new CustomSet([3, 1, 2, 1]).toList();
+    var expected3 = [1, 2, 3];
+    expect(actual3.sort()).toEqual(expected3);
+  });
+`
+
+function render ({suiteData, testBodyTemplates, extraTests, suiteTemplate}) {
+  var testCases = extractTestCases(suiteData, testBodyTemplates);
+  var tests = renderTests(testCases);
+
+  return renderSuite(tests, extraTests, suiteTemplate);
+}
+
+function extractTestCases (suiteData, testBodyTemplates) {
+  var testCases = [];
+
+  Object.keys(suiteData)
+    .filter(function (key) {
+      return key !== METADATA_COMMENT_KEY;
+    })
+    .forEach(function (sectionName) {
+      suiteData[sectionName]['cases']
+        .forEach(function (caseData) {
+          testCases.push(new TestCase(caseData, testBodyTemplates[sectionName]));
+        })
+    })
+
+  return testCases;
+}
+
+function TestCase (caseData, bodyTemplate) {
+  this.caseData = caseData;
+  this.bodyTemplate = bodyTemplate;
+}
+
+TestCase.prototype.render = function (isEnabled) {
+  return testTemplate(isEnabled, this.caseData.description, this.bodyTemplate(this.caseData));
+}
+
+function renderTests (testCases) {
+  return testCases.reduce(function (output, testCase, index) {
+    return output + testCase.render(index === 0);
+  }, '')
+}
+
+function renderSuite (tests, otherTests, suiteTemplate) {
+  return suiteTemplate(tests.concat(otherTests));
+}
+
+function suiteTemplate (tests) {
+  return (
+`var CustomSet = require('./custom-set');
+
+describe('CustomSet', function() {
+${tests}
+});
+`);
+}
+
+function testTemplate (isEnabled, description, body) {
+  return (
+`
+  ${isEnabled ? 'it' : 'xit'}('${description}', function() {
+    ${body}
+  });
+`);
+}
+
+function array (array) {
+  return array.length === 0 ? '' : `[${array.join(', ')}]`;
+}
+
+function generate () {
+  var exerciseFilePath = path.join(EXERCISE_METADATA_ROOT, EXERCISE_DIR_NAME, METADATA_FILE_NAME);
+  var suiteData = JSON.parse(fs.readFileSync(exerciseFilePath));
+
+  return fs.writeFileSync(
+    SPEC_FILE_NAME,
+    render({
+      suiteData: suiteData,
+      testBodyTemplates: TEST_BODY_TEMPLATES,
+      extraTests: NON_CANONICAL_TESTS,
+      suiteTemplate: suiteTemplate
+    }));
+}
+
+generate();


### PR DESCRIPTION
Fixes #292

The spec for this exercise is now generated from the common exercise metadata.

Due to the metadata test cases being one assertion per case, there are now more tests in the suite.

The existing non-canonical tests have been appended after the new generated tests.