### PR TITLE
Align word count with the x-common reference

### DIFF
--- a/exercises/word-count/example.js
+++ b/exercises/word-count/example.js
@@ -4,15 +4,15 @@ function Words() {}
 
 Words.prototype.count = function (input) {
   var counts = {};
-  var words = input.match(/\S+/g);
+  var words = input.toLowerCase()
+                   .replace(/[,."\/!&@$%\^\*;:{}()¡¿?]/g, ' ')
+                   .replace(/\s'(\w+)'\s/, ' '+'$1'+' ')
+                   .match(/\S+/g);
 
   words.forEach(function (word) {
-    var lcWord = word.toLowerCase();
-    counts[lcWord] = counts.hasOwnProperty(lcWord) ? counts[lcWord] + 1 : 1;
+    counts[word] = counts.hasOwnProperty(word) ? counts[word] + 1 : 1;
   });
-
   return counts;
 };
 
 module.exports = Words;
-

--- a/exercises/word-count/word-count.spec.js
+++ b/exercises/word-count/word-count.spec.js
@@ -8,19 +8,24 @@ describe('count()', function() {
     expect(words.count('word')).toEqual(expectedCounts);
   });
 
-  xit('counts one of each', function() {
+  xit('counts one of each word', function() {
     var expectedCounts = { one: 1, of: 1, each: 1 };
     expect(words.count('one of each')).toEqual(expectedCounts);
   });
 
-  xit('counts multiple occurrences', function() {
+  xit('counts multiple occurrences of a word', function() {
     var expectedCounts = { one: 1, fish: 4, two: 1, red: 1, blue: 1 };
     expect(words.count('one fish two fish red fish blue fish')).toEqual(expectedCounts);
   });
 
-  xit('includes punctuation', function() {
-    var expectedCounts = { car: 1, ':': 2, carpet: 1, as: 1, java: 1, 'javascript!!&@$%^&': 1 };
-    expect(words.count('car : carpet as java : javascript!!&@$%^&')).toEqual(expectedCounts);
+  xit('handles cramped lists', function() {
+    var expectedCounts = { one: 1, two: 1, three: 1 };
+    expect(words.count('one,two,three')).toEqual(expectedCounts);
+  });
+
+  xit('ignores punctuation', function() {
+    var expectedCounts = { car: 1, carpet: 1, as: 1, java: 1, javascript: 1 };
+    expect(words.count('car : carpet as java: javascript!!&@$%^&')).toEqual(expectedCounts);
   });
 
   xit('includes numbers', function() {
@@ -33,8 +38,18 @@ describe('count()', function() {
     expect(words.count('go Go GO')).toEqual(expectedCounts);
   });
 
+  xit('counts words with apostrophes', function() {
+    var expectedCounts = { 'first': 1, 'don\'t': 2, 'laugh': 1, 'then': 1, 'cry': 1 };
+    expect(words.count('First: don\'t laugh. Then: don\'t cry.')).toEqual(expectedCounts);
+  });
+
+  xit('counts words with quotations', function() {
+    var expectedCounts = { 'joe': 1, 'can\'t': 1, 'tell': 1, 'between': 1, 'large': 2, 'and': 1 };
+    expect(words.count('Joe can\'t tell between \'large\' and large.')).toEqual(expectedCounts);
+  });
+
   xit('counts properly international characters', function() {
-    var expectedCounts = { '¡hola!': 1, '¿qué': 1, 'tal?': 1, 'привет!': 1 };
+    var expectedCounts = { 'hola': 1, 'qué': 1, 'tal': 1, 'привет': 1 };
     expect(words.count('¡Hola! ¿Qué tal? Привет!')).toEqual(expectedCounts);
   });
 
@@ -43,7 +58,7 @@ describe('count()', function() {
     expect(words.count('hello\nworld')).toEqual(expectedCounts);
   });
 
-  xit('counts tabs', function() {
+  xit('counts tabs as white space', function() {
     var expectedCounts = { hello: 1, world: 1 };
     expect(words.count('hello\tworld')).toEqual(expectedCounts);
   });
@@ -59,7 +74,7 @@ describe('count()', function() {
   });
 
   xit('handles properties that exist on Object’s prototype', function() {
-    var expectedCounts = { reserved: 1, words: 1, like: 1, constructor: 1, and: 1, tostring: 1, 'ok?': 1 };
+    var expectedCounts = { reserved: 1, words: 1, like: 1, constructor: 1, and: 1, tostring: 1, ok: 1 };
     expect(words.count('reserved words like constructor and toString ok?')).toEqual(expectedCounts);
   });
 });


### PR DESCRIPTION
This brings the javascript word-count test in alignment with the x-common, so that all the tests referenced in x-common are now included in the javascript version.  The additional existing tests were maintained.

Addresses Issue #305 so that punctuation is handled the same in javascript as it is described in x-common, i.e., punctuation is not considered part of the word L26, L52, L77.

Also, added the the cramped list, apostrophe, and single quotes test from x-common L21, L41, L46 and clarified the test intent on L11, L16, L61.

Finally, updated the example.js code so that it passed all the new test.  This added two replace commands on L7-8 and I simplified the <code>.forEach( function(word) {</code> by moving the <code>.toLowerCase()</code> function to L7.