### PR TITLE
Move unicode problems up the list in `config.json`

### DIFF
--- a/config.json
+++ b/config.json
@@ -100,9 +100,28 @@
       ]
     },
     {
+      "slug": "pangram",
+      "difficulty": 1,
+      "topics": [
+        "Control flow (conditionals)",
+        "Control flow (loops)",
+        "Lists",
+        "Strings",
+        "Maps",
+        "Algorithms",
+        "Searching"
+      ]
+    },
+    {
       "slug": "bob",
       "difficulty": 1,
       "topics": [
+        "Control flow (conditionals)",
+        "Polymorfism",
+        "Strings",
+        "Unicode",
+        "Pattern recognition",
+        "Regular expressions"
       ]
     },
     {
@@ -112,19 +131,7 @@
       ]
     },
     {
-      "slug": "word-count",
-      "difficulty": 1,
-      "topics": [
-      ]
-    },
-    {
       "slug": "isogram",
-      "difficulty": 1,
-      "topics": [
-      ]
-    },
-    {
-      "slug": "pangram",
       "difficulty": 1,
       "topics": [
       ]
@@ -193,6 +200,17 @@
       "slug": "clock",
       "difficulty": 1,
       "topics": [
+      ]
+    },
+    {
+      "slug": "word-count",
+      "difficulty": 1,
+      "topics": [
+        "Control flow (loops)",
+        "Lists",
+        "Strings",
+        "Unicode",
+        "Regular expressions"
       ]
     },
     {


### PR DESCRIPTION
Word Count problem is moved to position 20th, because it introduces
users to a Unicode complex problem.

Bob problem, although likely dealing with Unicode subjects, is kept
because it can be reasonably solved without knowing too much about
Unicode.

Pangram is moved just before Bob.

Topics are configured in `config.json` for all three problems.

Addresses #321