### PR TITLE
Robot-simulator: require throwing exception

### DIFF
--- a/exercises/robot-simulator/example.js
+++ b/exercises/robot-simulator/example.js
@@ -10,6 +10,13 @@ Robot.prototype.at = function (xcoord, ycoord) {
 };
 
 Robot.prototype.orient = function (direction) {
+  if (direction != 'north' &&
+      direction != 'south' &&
+      direction != 'east' &&
+      direction != 'west') {
+    throw 'Invalid Robot Bearing'
+  }
+
   this.bearing = direction;
   return 'The robot is pointed ' + direction;
 };

--- a/exercises/robot-simulator/robot-simulator.spec.js
+++ b/exercises/robot-simulator/robot-simulator.spec.js
@@ -14,11 +14,11 @@ describe('Robot', function() {
   });
 
   xit('invalid robot bearing', function() {
-    try {
+    var incorrectlyOrientRobot = function () {
       robot.orient('crood');
-    } catch(exception) {
-      expect(exception).toEqual('Invalid Robot Bearing');
-    }
+    };
+
+    expect(incorrectlyOrientRobot).toThrow(new Error('Invalid Robot Bearing'));
   });
 
   xit('turn right from north', function() {


### PR DESCRIPTION
The original test passes without any assertions if `robot.orient` doesn't throw an exception