### PR TITLE
Edit leap year stub to be consistent with tests

### DIFF
--- a/exercises/leap/HINT.md
+++ b/exercises/leap/HINT.md
@@ -1,9 +1,11 @@
 This is the first test for this exercise:
 
+```javascript
   it('is not very common', function() {
     var year = new Year(2015);
     expect(year.isLeap()).toBe(false);
   });
+```
 
 Each test in the exercise follows the same pattern: 
 
@@ -14,7 +16,9 @@ The `Year` function is a constructor, which means that it is specifically design
 
 When a new `Year` object is created:
 
+```javascript
   var year = new Year(2015);
+```
 
 We expect `year` to, at the very least, have a specific value (in this case 2015) assigned to it.  Otherwise it would not represent an actual year.
 
@@ -22,17 +26,21 @@ This means that we must store the value passed as a parameter when the new `Year
 
 The way a constructor stores these fundamental values (instance variables) is like this:
 
+```javascript
   var Constructor = function(input) {
     this.value = input;
   };
+```
 
 The `this` in the constructor refers to the newly created instance of the `Constructor`.
 
 Once the input (parameter) is stored in an instance variable, any instance methods, such as:
 
+```javascript
   Constructor.prototype.instanceMethod = function() {
     // this method can now access the input by calling `this.value`
   };
+```
 
 The instance method accesses the input using `this.value` (in this example).
 

--- a/exercises/leap/HINT.md
+++ b/exercises/leap/HINT.md
@@ -1,0 +1,44 @@
+This is the first test for this exercise:
+
+  it('is not very common', function() {
+    var year = new Year(2015);
+    expect(year.isLeap()).toBe(false);
+  });
+
+Each test in the exercise follows the same pattern: 
+
+  1. A new Year is instantiated with a value and stored in a variable: year.
+  2. The test calls an instance method, isLeap(), from the variable `year`.
+
+The `Year` function is a constructor, which means that it is specifically designed to provide a template for new objects.
+
+When a new `Year` object is created:
+
+  var year = new Year(2015);
+
+We expect `year` to, at the very least, have a specific value (in this case 2015) assigned to it.  Otherwise it would not represent an actual year.
+
+This means that we must store the value passed as a parameter when the new `Year` is created (2015), so that the new `Year` can access it.
+
+The way a constructor stores these fundamental values (instance variables) is like this:
+
+  var Constructor = function(input) {
+    this.value = input;
+  };
+
+The `this` in the constructor refers to the newly created instance of the `Constructor`.
+
+Once the input (parameter) is stored in an instance variable, any instance methods, such as:
+
+  Constructor.prototype.instanceMethod = function() {
+    // this method can now access the input by calling `this.value`
+  };
+
+The instance method accesses the input using `this.value` (in this example).
+
+This is why code needs to be written in two separate functions:
+
+  1. The first function, `Year`, is a constructor that serves as a template for year objects that are created with their value (such as 2015).
+     This function needs to store the input when a new `Year` is created.
+  2. The second function, isLeap(), is an instance method that is called from a new `year`. 
+     This function (method) should contain the logic to determine if the given year is a leap year.

--- a/exercises/leap/leap.js
+++ b/exercises/leap/leap.js
@@ -3,9 +3,13 @@
 // convenience to get you started writing code faster.
 //
 
-var Year = function() {};
+var Year = function(input) {
+//
+// YOUR CODE GOES HERE
+//  
+};
 
-Year.prototype.isLeap = function(input) {
+Year.prototype.isLeap = function() {
 //
 // YOUR CODE GOES HERE
 //


### PR DESCRIPTION
Rewriting the stub was trivial, but this is only the second exercise in the track and writing the class in this way makes complete sense, because we intuitively would want to instantiate a `Year` with a value, but it requires the beginning user to initialize the instance variable in one section of code and the `isLeap` logic in the instance method.  

Perhaps it would be better to leave the stub as it is and rewrite the tests so that `isLeap` takes the year parameter.  Even though this is a counter-intuitive design for the `Year` class, I believe it would be less intimidating for beginning users.  I would be glad to revise the tests if that is what is decided.