### PR TITLE
Update testing instructions on all exercises

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ test-assignment: node_modules
 	@cp exercises/$(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(subst _,-,$(ASSIGNMENT)).$(FILEEXT)
 	#@sed -i.original 's/\bxit\b/it/g' $(OUTDIR)/*spec.$(FILEEXT)
 	@sed 's/xit/it/g' exercises/$(ASSIGNMENT)/$(TSTFILE) > $(OUTDIR)/$(TSTFILE)
-	@./node_modules/.bin/jasmine-node --captureExceptions $(OUTDIR)/$(TSTFILE)
+	@./node_modules/.bin/jasmine --captureExceptions $(OUTDIR)/$(TSTFILE)
 
 test:
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
-

--- a/SETUP.md
+++ b/SETUP.md
@@ -9,10 +9,9 @@ http://exercism.io/languages/javascript
 
 Execute the tests with:
 
-    jasmine-node .
+    jasmine .
 
 In many test suites all but the first test have been skipped.
 
 Once you get a test passing, you can unskip the next one by
 changing `xit` to `it`.
-

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -15,15 +15,14 @@ If you are using a different distribution or package manager, you can find a com
 
 ## Installing additional tools
 
-The next step is to install `jasmine-node` globally so that you can run JavaScript tests:
+The next step is to install [Jasmine](https://jasmine.github.io/) globally so that you can run JavaScript tests:
 
-    npm install jasmine-node -g
+    npm install -g jasmine
 
 Depending on your setup, you may need super user privileges to install an `npm` module globally. This is the case if you've used the official installer linked to above. If `npm` gives you an error saying you don't have access, add `sudo` to the command above:
 
-    sudo npm install jasmine-node -g
+    sudo npm install -g jasmine
 
 If you've used the official installer, your `PATH` should have been automatically configured, but if your shell has trouble locating your globally installed modules&mdash;or if you build Node.js from source&mdash;update your `PATH` to include the `npm` binaries by adding the following to either `~/.bash_profile` or `~/.zshrc`:
 
     export PATH=/usr/local/share/npm/bin:$PATH
-

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -6,10 +6,10 @@ or you can fetch a specific exercise, passing the exercise name after the langua
 
     exercism fetch javascript bob
 
-Now, it's time to run some tests. Move to the folder where that exercise's files are located (a path similar to `<EXERCISM_HOME_DIR>/<TRACK_ID>/<EXERCISE>`) and run the tests with the `jasmine-node` command you should have installed on the *Installing JavaScript* step:
+Now, it's time to run some tests. Move to the folder where that exercise's files are located (a path similar to `<EXERCISM_HOME_DIR>/<TRACK_ID>/<EXERCISE>`) and run the tests with the `jasmine` command you should have installed on the *Installing JavaScript* step:
 
     cd ~/exercism/javascript/bob
-    jasmine-node bob_test.spec.js
+    jasmine bob_test.spec.js
 
 *Note that `~/exercism` is the default folder for `EXERCISM_HOME_DIR`. Be sure you use your configured folder for it*
 

--- a/exercises/acronym/package.json
+++ b/exercises/acronym/package.json
@@ -7,6 +7,6 @@
     "test": "make test"
   },
   "devDependencies": {
-    "jasmine-node": "*"
+    "jasmine": "*"
   }
 }

--- a/exercises/hello-world/HINTS.md
+++ b/exercises/hello-world/HINTS.md
@@ -24,7 +24,7 @@ This is the first test:
 
 Run the test now, with the following command on the command-line:
 
-    jasmine-node .
+    jasmine .
 
 The test fails, which makes sense since you've not written any code yet.
 
@@ -76,7 +76,7 @@ Try changing the function in hello-world.js so that it says
 
 Then run the tests again from the command-line:
 
-    jasmine-node .
+    jasmine .
 
 Notice how it changes the failure message.
 
@@ -89,7 +89,7 @@ Once the test is passing, look at the second test in hello-world.spec.js. It loo
     });
 
 This test starts with `xit` instead of `it`.
-That means that when jasmine-node runs the tests,
+That means that when Jasmine runs the tests,
 the test will be skipped.
 
 Change the test so that it starts with `it`,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "test": "make test"
   },
   "devDependencies": {
-    "jasmine-node": "*"
+    "jasmine": "*"
   }
 }


### PR DESCRIPTION
**Blocked by #344**

--

According to discussions in #341 we'll use Jasmine as a command line tool, globally installed through npm, and the testing command should now look like `jasmine ./test-file.spec.js`.

- [x] Change references for `jasmine-node` to `jasmine`  
  `❯ grep -lr "jasmine-node" .`
  - [x] `./docs/INSTALLATION.md`
  - [x] `./docs/TESTS.md`
  - [x] `./exercises/acronym/package.json`
  - [x] `./exercises/hello-world/HINTS.md`
  - [x] `./Makefile`
  - [x] `./package.json`
  - [x] `./SETUP.md`
- [x] Get #343 accepted
- [x] Get #344 accepted