### PR TITLE
Updates test instructions on Hello World's HINTS.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -9,7 +9,12 @@ http://exercism.io/languages/javascript
 
 Execute the tests with:
 
-    jasmine .
+    jasmine <exercise-name>.spec.js
+
+Replace `<exercise-name>` with the name of the current exercise. E.g., to
+test the Hello World exercise:
+
+    jasmine hello-world.spec.js
 
 In many test suites all but the first test have been skipped.
 

--- a/exercises/hello-world/HINTS.md
+++ b/exercises/hello-world/HINTS.md
@@ -24,7 +24,7 @@ This is the first test:
 
 Run the test now, with the following command on the command-line:
 
-    jasmine .
+    jasmine hello-world.spec.js
 
 The test fails, which makes sense since you've not written any code yet.
 
@@ -76,7 +76,7 @@ Try changing the function in hello-world.js so that it says
 
 Then run the tests again from the command-line:
 
-    jasmine .
+    jasmine hello-world.spec.js
 
 Notice how it changes the failure message.
 


### PR DESCRIPTION
This PR refers to #349, which @ronalson reported that instructions to test exercises are just to run `jasmine .`, when it should actually be `jasmine your-exercise-test-file.spec.js`.