### PR TITLE
Add first patch labels to probot exempt

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,6 @@
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - good first patch
+  - first-timers only


### PR DESCRIPTION
We want to keep these issues open indefinitely for first-timers.
Tell probot to ignore them so that they are never closed
automatically.

`pinned` and `security` are default. I added `good first patch` and
`first-timers only`.

Ref: https://github.com/exercism/xecmascript/pull/293#issuecomment-302931135