### PR TITLE
Add extended ascii character test for isogram.

### DIFF
--- a/exercises/isogram/isogram.spec.js
+++ b/exercises/isogram/isogram.spec.js
@@ -60,5 +60,11 @@ describe('Isogram Test Suite', function () {
 
     expect(word.isIsogram()).toEqual(false);
   });
+  
+  xit('Àcrobàt', function () {
+    var word = new Isogram('Àcrobàt');
+
+    expect(word.isIsogram()).toEqual(false);
+  });
 
 });


### PR DESCRIPTION
Tests a word which includes both upper and lower case of an extended ascii character. See issues [#359](https://github.com/exercism/xjavascript/issues/359) and [#323](https://github.com/exercism/xjavascript/issues/323).